### PR TITLE
Add keyboard padding and margin feature

### DIFF
--- a/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.java
+++ b/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.java
@@ -104,18 +104,18 @@ public class InsetterBindingAdapters {
 
   @BindingAdapter(
             value = {
-                    "marginBottomForKeyboard",
-                    "paddingBottomForKeyboard"
+                    "marginBottomForIme",
+                    "paddingBottomForIme"
             },
             requireAll = false)
-  public static void applyKeyboardInsetsFromBooleans(
+  public static void applyImeInsetsFromBooleans(
             @NonNull final View v,
-            final boolean marginBottomForKeyboard,
-            final boolean paddingBottomForKeyboard) {
-      Insetter.applyInsetsWhenKeyboardDisplayed(
+            final boolean marginBottomForIme,
+            final boolean paddingBottomForIme) {
+      Insetter.applyInsetsWhenImeDisplayed(
               v,
-              marginBottomForKeyboard,
-              paddingBottomForKeyboard);
+              marginBottomForIme,
+              paddingBottomForIme);
   }
 
   @BindingAdapter("layout_edgeToEdge")

--- a/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.java
+++ b/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.java
@@ -102,6 +102,22 @@ public class InsetterBindingAdapters {
         });
   }
 
+  @BindingAdapter(
+            value = {
+                    "marginBottomForKeyboard",
+                    "paddingBottomForKeyboard"
+            },
+            requireAll = false)
+  public static void applyKeyboardInsetsFromBooleans(
+            @NonNull final View v,
+            final boolean marginBottomForKeyboard,
+            final boolean paddingBottomForKeyboard) {
+      Insetter.applyInsetsWhenKeyboardDisplayed(
+              v,
+              marginBottomForKeyboard,
+              paddingBottomForKeyboard);
+  }
+
   @BindingAdapter("layout_edgeToEdge")
   public static void setEdgeToEdgeFlags(@NonNull final View view, boolean enabled) {
     if (Build.VERSION.SDK_INT >= 16) {

--- a/ktx/src/main/java/dev/chrisbanes/insetter/viewinsetter.kt
+++ b/ktx/src/main/java/dev/chrisbanes/insetter/viewinsetter.kt
@@ -48,11 +48,11 @@ fun View.requestApplyInsetsWhenAttached() {
 fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean) = Insetter.setEdgeToEdgeSystemUiFlags(this, enabled)
 
 /**
- * Applies padding or margin to the bottom of the view when the keyboard is displayed
+ * Applies padding or margin to the bottom of the view when the IME (keyboard) is displayed
  * @param marginBottom whether to adjust the view's bottom margin
  * @param paddingBottom whether to adjust the view's bottom padding
  */
-fun View.applyInsetsWhenKeyboardDisplayed(marginBottom: Boolean = false,
+fun View.applyInsetsWhenIMEDisplayed(marginBottom: Boolean = false,
                                           paddingBottom: Boolean = false) {
-    Insetter.applyInsetsWhenKeyboardDisplayed(this, marginBottom, paddingBottom)
+    Insetter.applyInsetsWhenImeDisplayed(this, marginBottom, paddingBottom)
 }

--- a/ktx/src/main/java/dev/chrisbanes/insetter/viewinsetter.kt
+++ b/ktx/src/main/java/dev/chrisbanes/insetter/viewinsetter.kt
@@ -46,3 +46,13 @@ fun View.requestApplyInsetsWhenAttached() {
  */
 @RequiresApi(16)
 fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean) = Insetter.setEdgeToEdgeSystemUiFlags(this, enabled)
+
+/**
+ * Applies padding or margin to the bottom of the view when the keyboard is displayed
+ * @param marginBottom whether to adjust the view's bottom margin
+ * @param paddingBottom whether to adjust the view's bottom padding
+ */
+fun View.applyInsetsWhenKeyboardDisplayed(marginBottom: Boolean = false,
+                                          paddingBottom: Boolean = false) {
+    Insetter.applyInsetsWhenKeyboardDisplayed(this, marginBottom, paddingBottom)
+}

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.java
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.java
@@ -413,7 +413,7 @@ public class Insetter {
     view.getWindowVisibleDisplayFrame(visibleWindowBounds);
     int visibleWindowHeight = visibleWindowBounds.height();
     int heightDiff = view.getRootView().getHeight() - visibleWindowHeight;
-    int marginOfError = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 50, view.getResources().getDisplayMetrics()));
+    int marginOfError = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 100, view.getResources().getDisplayMetrics()));
     return heightDiff > marginOfError;
   }
 

--- a/library/src/main/res/values/dimensions.xml
+++ b/library/src/main/res/values/dimensions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="ime_margin">100dp</dimen>
+</resources>

--- a/sample/src/main/res/drawable/ic_add_circle_black_24dp.xml
+++ b/sample/src/main/res/drawable/ic_add_circle_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z"/>
+</vector>

--- a/sample/src/main/res/layout/activity_data_binding.xml
+++ b/sample/src/main/res/layout/activity_data_binding.xml
@@ -26,7 +26,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:paddingBottomForKeyboard="@{true}">
 
         <ImageView
             android:layout_width="match_parent"
@@ -41,7 +42,7 @@
 
         <ScrollView
             android:layout_width="260dp"
-            android:layout_height="200dp"
+            android:layout_height="wrap_content"
             android:layout_gravity="center">
 
             <LinearLayout
@@ -72,6 +73,13 @@
                     android:layout_height="wrap_content"
                     android:checked="@={state.paddingBottomSystemWindow}"
                     android:text="Padding: systemWindowInsets - Bottom" />
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Test keyboard resize"
+                    android:gravity="top"
+                    android:lines="20"/>
 
             </LinearLayout>
 

--- a/sample/src/main/res/layout/activity_data_binding.xml
+++ b/sample/src/main/res/layout/activity_data_binding.xml
@@ -27,7 +27,7 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:paddingBottomForKeyboard="@{true}">
+        app:paddingBottomForIme="@{true}">
 
         <ImageView
             android:layout_width="match_parent"
@@ -84,6 +84,14 @@
             </LinearLayout>
 
         </ScrollView>
+
+        <ImageView
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:src="@drawable/ic_add_circle_black_24dp"
+            app:layout_marginBottomSystemWindowInsets="@{true}" />
 
     </FrameLayout>
 </layout>


### PR DESCRIPTION
Typically, we use "adjustResize" in the manifest to automatically resize an activity so that the keyboard doesn't cover up the content. However, edge-to-edge breaks that. This PR adds the ability to add padding or margin, equivalent to the height of the keyboard (same as `SystemWindowInsetBottom`), to the bottom of a view when the keyboard is shown.

Included in this PR:

- Java Insetter method
- Extension function
- Databinding adapter
- Addition to DataBindingSample sample to test that it works