### PR TITLE
Set the default of setEdgeToEdgeSystemUiFlags to true

### DIFF
--- a/ktx/src/main/java/dev/chrisbanes/insetter/viewinsetter.kt
+++ b/ktx/src/main/java/dev/chrisbanes/insetter/viewinsetter.kt
@@ -45,4 +45,4 @@ fun View.requestApplyInsetsWhenAttached() {
  * @see Insetter.setEdgeToEdgeSystemUiFlags
  */
 @RequiresApi(16)
-fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean) = Insetter.setEdgeToEdgeSystemUiFlags(this, enabled)
+fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) = Insetter.setEdgeToEdgeSystemUiFlags(this, enabled)


### PR DESCRIPTION
This allows for a nicer api so you can just call `view.setEdgeToEdgeSystemUiFlags()`