### PR TITLE
Apply insets for root InsetterConstraintLayout

### DIFF
--- a/widgets/src/androidTest/java/dev/chrisbanes/insetter/widgets/InsetterConstraintLayoutTestCase.kt
+++ b/widgets/src/androidTest/java/dev/chrisbanes/insetter/widgets/InsetterConstraintLayoutTestCase.kt
@@ -19,7 +19,8 @@ package dev.chrisbanes.insetter.widgets
 import android.app.Activity
 import android.graphics.Rect
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.FrameLayout
+import androidx.core.graphics.Insets
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -37,7 +38,7 @@ class InsetsConstraintLayoutTestCase {
     @get:Rule
     val rule = ActivityScenarioRule(Activity::class.java)
 
-    private lateinit var container: ConstraintLayout
+    private lateinit var container: FrameLayout
 
     @Before
     fun setup() {
@@ -97,9 +98,14 @@ class InsetsConstraintLayoutTestCase {
         val systemWindowInsets = insets.systemWindowInsets
         val systemGestureInsets = insets.systemGestureInsets
 
-        // -------------------------------------------
-        // Assert the system window padding views
-        // -------------------------------------------
+        assertSystemWindowPaddingView(systemWindowInsets)
+        assertSystemWindowMarginView(systemWindowInsets)
+        assertSystemGesturePaddingView(systemGestureInsets)
+        assertSystemGestureMarginView(systemGestureInsets)
+        assertMixedInsetViews(systemWindowInsets, systemGestureInsets)
+    }
+
+    private fun assertSystemWindowPaddingView(systemWindowInsets: Insets) {
 
         with(container.findViewById<View>(R.id.padding_system_window_left)) {
             assertPadding(left = systemWindowInsets.left)
@@ -130,11 +136,49 @@ class InsetsConstraintLayoutTestCase {
                 systemWindowInsets.bottom + layoutPadding
             )
         }
+        with(container.findViewById<View>(R.id.container_padding_system_window_left)) {
+            assertPadding(left = systemWindowInsets.left)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_window_top)) {
+            assertPadding(top = systemWindowInsets.top)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_window_right)) {
+            assertPadding(right = systemWindowInsets.right)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_window_bottom)) {
+            assertPadding(bottom = systemWindowInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_window_all)) {
+            assertPadding(
+                left = systemWindowInsets.left,
+                top = systemWindowInsets.top,
+                right = systemWindowInsets.right,
+                bottom = systemWindowInsets.bottom
+            )
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_window_left)) {
+            assertPadding(left = systemWindowInsets.left)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_window_top)) {
+            assertPadding(top = systemWindowInsets.top)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_window_right)) {
+            assertPadding(right = systemWindowInsets.right)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_window_bottom)) {
+            assertPadding(bottom = systemWindowInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_window_all)) {
+            assertPadding(
+                left = systemWindowInsets.left,
+                top = systemWindowInsets.top,
+                right = systemWindowInsets.right,
+                bottom = systemWindowInsets.bottom
+            )
+        }
+    }
 
-        // -------------------------------------------
-        // Assert the system window margin views
-        // -------------------------------------------
-
+    private fun assertSystemWindowMarginView(systemWindowInsets: Insets) {
         with(container.findViewById<View>(R.id.margin_system_window_left)) {
             assertLayoutMargin(left = systemWindowInsets.left)
         }
@@ -164,11 +208,49 @@ class InsetsConstraintLayoutTestCase {
                 systemWindowInsets.bottom + layoutMargin
             )
         }
+        with(container.findViewById<View>(R.id.container_margin_system_window_left)) {
+            assertLayoutMargin(left = systemWindowInsets.left)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_window_top)) {
+            assertLayoutMargin(top = systemWindowInsets.top)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_window_right)) {
+            assertLayoutMargin(right = systemWindowInsets.right)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_window_bottom)) {
+            assertLayoutMargin(bottom = systemWindowInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_window_all)) {
+            assertLayoutMargin(
+                left = systemWindowInsets.left,
+                top = systemWindowInsets.top,
+                right = systemWindowInsets.right,
+                bottom = systemWindowInsets.bottom
+            )
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_window_left)) {
+            assertLayoutMargin(left = systemWindowInsets.left)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_window_top)) {
+            assertLayoutMargin(top = systemWindowInsets.top)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_window_right)) {
+            assertLayoutMargin(right = systemWindowInsets.right)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_window_bottom)) {
+            assertLayoutMargin(bottom = systemWindowInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_window_all)) {
+            assertLayoutMargin(
+                left = systemWindowInsets.left,
+                top = systemWindowInsets.top,
+                right = systemWindowInsets.right,
+                bottom = systemWindowInsets.bottom
+            )
+        }
+    }
 
-        // -------------------------------------------
-        // Assert the system gesture padding views
-        // -------------------------------------------
-
+    private fun assertSystemGesturePaddingView(systemGestureInsets: Insets) {
         with(container.findViewById<View>(R.id.padding_system_gesture_left)) {
             assertPadding(left = systemGestureInsets.left)
         }
@@ -198,11 +280,49 @@ class InsetsConstraintLayoutTestCase {
                 systemGestureInsets.bottom + layoutPadding
             )
         }
+        with(container.findViewById<View>(R.id.container_padding_system_gesture_left)) {
+            assertPadding(left = systemGestureInsets.left)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_gesture_top)) {
+            assertPadding(top = systemGestureInsets.top)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_gesture_right)) {
+            assertPadding(right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_gesture_bottom)) {
+            assertPadding(bottom = systemGestureInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.container_padding_system_gesture_all)) {
+            assertPadding(
+                left = systemGestureInsets.left,
+                top = systemGestureInsets.top,
+                right = systemGestureInsets.right,
+                bottom = systemGestureInsets.bottom
+            )
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_gesture_left)) {
+            assertPadding(left = systemGestureInsets.left)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_gesture_top)) {
+            assertPadding(top = systemGestureInsets.top)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_gesture_right)) {
+            assertPadding(right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_gesture_bottom)) {
+            assertPadding(bottom = systemGestureInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_system_gesture_all)) {
+            assertPadding(
+                left = systemGestureInsets.left,
+                top = systemGestureInsets.top,
+                right = systemGestureInsets.right,
+                bottom = systemGestureInsets.bottom
+            )
+        }
+    }
 
-        // -------------------------------------------
-        // Assert the system gesture margin views
-        // -------------------------------------------
-
+    private fun assertSystemGestureMarginView(systemGestureInsets: Insets) {
         with(container.findViewById<View>(R.id.margin_system_gesture_left)) {
             assertLayoutMargin(left = systemGestureInsets.left)
         }
@@ -232,10 +352,49 @@ class InsetsConstraintLayoutTestCase {
                 systemGestureInsets.bottom + layoutMargin
             )
         }
+        with(container.findViewById<View>(R.id.container_margin_system_gesture_left)) {
+            assertLayoutMargin(left = systemGestureInsets.left)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_gesture_top)) {
+            assertLayoutMargin(top = systemGestureInsets.top)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_gesture_right)) {
+            assertLayoutMargin(right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_gesture_bottom)) {
+            assertLayoutMargin(bottom = systemGestureInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.container_margin_system_gesture_all)) {
+            assertLayoutMargin(
+                left = systemGestureInsets.left,
+                top = systemGestureInsets.top,
+                right = systemGestureInsets.right,
+                bottom = systemGestureInsets.bottom
+            )
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_gesture_left)) {
+            assertLayoutMargin(left = systemGestureInsets.left)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_gesture_top)) {
+            assertLayoutMargin(top = systemGestureInsets.top)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_gesture_right)) {
+            assertLayoutMargin(right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_gesture_bottom)) {
+            assertLayoutMargin(bottom = systemGestureInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.nested_margin_system_gesture_all)) {
+            assertLayoutMargin(
+                left = systemGestureInsets.left,
+                top = systemGestureInsets.top,
+                right = systemGestureInsets.right,
+                bottom = systemGestureInsets.bottom
+            )
+        }
+    }
 
-        // -------------------------------------------
-        // Assert the mixed inset views
-        // -------------------------------------------
+    private fun assertMixedInsetViews(systemWindowInsets: Insets, systemGestureInsets: Insets) {
 
         with(container.findViewById<View>(R.id.padding_syswin_left_gest_right)) {
             assertPadding(left = systemWindowInsets.left, right = systemGestureInsets.right)
@@ -247,9 +406,36 @@ class InsetsConstraintLayoutTestCase {
             assertPadding(top = systemWindowInsets.top, bottom = systemWindowInsets.bottom)
             assertLayoutMargin(left = systemGestureInsets.left, right = systemGestureInsets.right)
         }
+        with(container.findViewById<View>(R.id.container_padding_syswin_left_gest_right)) {
+            assertPadding(left = systemWindowInsets.left, right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.container_padding_syswin_top_gest_bottom)) {
+            assertPadding(top = systemWindowInsets.top, bottom = systemGestureInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.container_padding_syswin_pad_vertical_gest_margin_horiz)) {
+            assertPadding(top = systemWindowInsets.top, bottom = systemWindowInsets.bottom)
+            assertLayoutMargin(left = systemGestureInsets.left, right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_syswin_left_gest_right)) {
+            assertPadding(left = systemWindowInsets.left, right = systemGestureInsets.right)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_syswin_top_gest_bottom)) {
+            assertPadding(top = systemWindowInsets.top, bottom = systemGestureInsets.bottom)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_syswin_pad_vertical_gest_margin_horiz)) {
+            assertPadding(top = systemWindowInsets.top, bottom = systemWindowInsets.bottom)
+            assertLayoutMargin(left = systemGestureInsets.left, right = systemGestureInsets.right)
+        }
+
         // Assert that a view with paddingSystemWindowInsets="top" and
         // paddingSystemGestureInsets="top", the gesture insets win
         with(container.findViewById<View>(R.id.padding_syswin_top_gest_top)) {
+            assertPadding(top = systemGestureInsets.top)
+        }
+        with(container.findViewById<View>(R.id.container_padding_syswin_top_gest_top)) {
+            assertPadding(top = systemGestureInsets.top)
+        }
+        with(container.findViewById<View>(R.id.nested_padding_syswin_top_gest_top)) {
             assertPadding(top = systemGestureInsets.top)
         }
     }

--- a/widgets/src/androidTest/res/layout/include_layout_mixedinsets_cl.xml
+++ b/widgets/src/androidTest/res/layout/include_layout_mixedinsets_cl.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_syswin_left_gest_right"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        app:paddingSystemGestureInsets="right"
+        app:paddingSystemWindowInsets="left">
+
+        <View
+            android:id="@+id/nested_padding_syswin_left_gest_right"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="right"
+            app:paddingSystemWindowInsets="left" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_syswin_top_gest_bottom"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        app:paddingSystemGestureInsets="bottom"
+        app:paddingSystemWindowInsets="top">
+
+        <View
+            android:id="@+id/nested_padding_syswin_top_gest_bottom"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="bottom"
+            app:paddingSystemWindowInsets="top" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_syswin_top_gest_top"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        app:paddingSystemGestureInsets="top"
+        app:paddingSystemWindowInsets="top">
+
+        <View
+            android:id="@+id/nested_padding_syswin_top_gest_top"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="top"
+            app:paddingSystemWindowInsets="top" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_syswin_pad_vertical_gest_margin_horiz"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        app:layout_marginSystemGestureInsets="left|right"
+        app:paddingSystemWindowInsets="top|bottom">
+
+        <View
+            android:id="@+id/nested_padding_syswin_pad_vertical_gest_margin_horiz"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemGestureInsets="left|right"
+            app:paddingSystemWindowInsets="top|bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+</merge>

--- a/widgets/src/androidTest/res/layout/include_layout_sysgest_margin_container_layout.xml
+++ b/widgets/src/androidTest/res/layout/include_layout_sysgest_margin_container_layout.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_gesture_left"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemGestureInsets="left">
+
+        <View
+            android:id="@+id/nested_margin_system_gesture_left"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemGestureInsets="left" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_gesture_top"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemGestureInsets="top">
+
+        <View
+            android:id="@+id/nested_margin_system_gesture_top"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemGestureInsets="top" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_gesture_right"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemGestureInsets="right">
+
+        <View
+            android:id="@+id/nested_margin_system_gesture_right"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemGestureInsets="right" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_gesture_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemGestureInsets="bottom">
+
+        <View
+            android:id="@+id/nested_margin_system_gesture_bottom"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemGestureInsets="bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_gesture_all"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemGestureInsets="left|top|right|bottom">
+
+        <View
+            android:id="@+id/nested_margin_system_gesture_all"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemGestureInsets="left|top|right|bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+</merge>

--- a/widgets/src/androidTest/res/layout/include_layout_sysgest_padding_container_layout.xml
+++ b/widgets/src/androidTest/res/layout/include_layout_sysgest_padding_container_layout.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_gesture_left"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemGestureInsets="left" >
+
+        <View
+            android:id="@+id/nested_padding_system_gesture_left"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="left" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_gesture_top"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemGestureInsets="top" >
+
+        <View
+            android:id="@+id/nested_padding_system_gesture_top"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="top" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_gesture_right"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemGestureInsets="right" >
+
+        <View
+            android:id="@+id/nested_padding_system_gesture_right"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="right" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_gesture_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemGestureInsets="bottom" >
+
+        <View
+            android:id="@+id/nested_padding_system_gesture_bottom"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_gesture_all"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemGestureInsets="left|top|right|bottom" >
+
+        <View
+            android:id="@+id/nested_padding_system_gesture_all"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemGestureInsets="left|top|right|bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+</merge>

--- a/widgets/src/androidTest/res/layout/include_layout_syswin_margin_container_layout.xml
+++ b/widgets/src/androidTest/res/layout/include_layout_syswin_margin_container_layout.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_window_left"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemWindowInsets="left">
+
+        <View
+            android:id="@+id/nested_margin_system_window_left"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemWindowInsets="left" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_window_top"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemWindowInsets="top">
+
+        <View
+            android:id="@+id/nested_margin_system_window_top"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemWindowInsets="top" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_window_right"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemWindowInsets="right">
+
+        <View
+            android:id="@+id/nested_margin_system_window_right"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemWindowInsets="right" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_window_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemWindowInsets="bottom">
+
+        <View
+            android:id="@+id/nested_margin_system_window_bottom"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemWindowInsets="bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_margin_system_window_all"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_marginSystemWindowInsets="left|top|right|bottom">
+
+        <View
+            android:id="@+id/nested_margin_system_window_all"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_marginSystemWindowInsets="left|top|right|bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+</merge>

--- a/widgets/src/androidTest/res/layout/include_layout_syswin_padding_container_layout.xml
+++ b/widgets/src/androidTest/res/layout/include_layout_syswin_padding_container_layout.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_window_left"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemWindowInsets="left">
+
+        <View
+            android:id="@+id/nested_padding_system_window_left"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemWindowInsets="left" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_window_top"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemWindowInsets="top">
+
+        <View
+            android:id="@+id/nested_padding_system_window_top"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemWindowInsets="top" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_window_right"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemWindowInsets="right">
+
+        <View
+            android:id="@+id/nested_padding_system_window_right"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemWindowInsets="right" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_window_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemWindowInsets="bottom" >
+
+        <View
+            android:id="@+id/nested_padding_system_window_bottom"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemWindowInsets="bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:id="@+id/container_padding_system_window_all"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:paddingSystemWindowInsets="left|top|right|bottom" >
+
+        <View
+            android:id="@+id/nested_padding_system_window_all"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:paddingSystemWindowInsets="left|top|right|bottom" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+</merge>

--- a/widgets/src/androidTest/res/layout/insetter_cl.xml
+++ b/widgets/src/androidTest/res/layout/insetter_cl.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2019 Google LLC
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +13,30 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include layout="@layout/include_layout_syswin_padding_children" />
-    <include layout="@layout/include_layout_syswin_margin_children" />
-    <include layout="@layout/include_layout_sysgest_padding_children" />
-    <include layout="@layout/include_layout_sysgest_margin_children" />
-    <include layout="@layout/include_layout_mixedinsets_children" />
+    <dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-</dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+        <include layout="@layout/include_layout_syswin_padding_children" />
+        <include layout="@layout/include_layout_syswin_margin_children" />
+        <include layout="@layout/include_layout_sysgest_padding_children" />
+        <include layout="@layout/include_layout_sysgest_margin_children" />
+        <include layout="@layout/include_layout_mixedinsets_children" />
+
+    </dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
+
+
+    <include layout="@layout/include_layout_syswin_padding_container_layout" />
+    <include layout="@layout/include_layout_syswin_margin_container_layout" />
+    <include layout="@layout/include_layout_sysgest_padding_container_layout" />
+    <include layout="@layout/include_layout_sysgest_margin_container_layout" />
+    <include layout="@layout/include_layout_mixedinsets_cl" />
+
+</FrameLayout>
+
+


### PR DESCRIPTION
Hello!
I propose to give developers the opportunity to process inserts with root InsetterConstraintLayout in order to avoid unnecessary duplication in some cases.

For example:
<details>
  <summary>Before</summary>

```xml
<dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:app="http://schemas.android.com/apk/res-auto"
    android:layout_width="match_parent"
    android:layout_height="match_parent">

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintStart_toStartOf="parent"
        app:layout_constraintTop_toTopOf="parent"
        app:paddingSystemWindowInsets="left|top" />

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintEnd_toEndOf="parent"
        app:layout_constraintTop_toTopOf="parent"
        app:paddingSystemWindowInsets="right|top" />

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintBottom_toBottomOf="parent"
        app:layout_constraintEnd_toEndOf="parent"
        app:paddingSystemWindowInsets="right|bottom" />

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintBottom_toBottomOf="parent"
        app:layout_constraintStart_toStartOf="parent"
        app:paddingSystemWindowInsets="left|bottom" />

</dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
```
</details>

<details>
  <summary>After</summary>

```xml
<dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout 
    xmlns:app="http://schemas.android.com/apk/res-auto"
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    app:paddingSystemWindowInsets="left|top|right|bottom" >

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintStart_toStartOf="parent"
        app:layout_constraintTop_toTopOf="parent" />

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintEnd_toEndOf="parent"
        app:layout_constraintTop_toTopOf="parent" />

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintBottom_toBottomOf="parent"
        app:layout_constraintEnd_toEndOf="parent" />

    <ImageView
        android:layout_width="48dp"
        android:layout_height="48dp"
        app:layout_constraintBottom_toBottomOf="parent"
        app:layout_constraintStart_toStartOf="parent" />

</dev.chrisbanes.insetter.widgets.constraintlayout.InsetterConstraintLayout>
```
</details>

WDYT?