### PR TITLE
Add requestLayout() call on parent view for pre 26 API level

### DIFF
--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.java
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.java
@@ -21,7 +21,6 @@ import android.os.Build;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
-
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,7 +30,6 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Locale;

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.java
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.java
@@ -17,9 +17,11 @@
 package dev.chrisbanes.insetter;
 
 import android.annotation.SuppressLint;
+import android.os.Build;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -29,6 +31,7 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.OnApplyWindowInsetsListener;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Locale;
@@ -441,6 +444,10 @@ public final class Insetter {
         mlp.rightMargin = marginRight;
         mlp.bottomMargin = marginBottom;
         view.setLayoutParams(lp);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+          view.getParent().requestLayout();
+        }
 
         if (Log.isLoggable(TAG, Log.DEBUG)) {
           Log.d(


### PR DESCRIPTION
Hello!

There is known bug in AOSP: measure cache of ViewGroup not cleared when updating child layout params, that was [fixed](https://cs.android.com/android/_/android/platform/frameworks/base/+/5429daaa510ae144ca9a9a7052980faf8d9b2087) in Android API level 26.

I add check for API level and call requestLayout() on parent view on pre 26 API levels. 