### PR TITLE
Support for the Android 11 WindowInsets types

### DIFF
--- a/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
+++ b/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
@@ -26,7 +26,7 @@ private const val TAG = "Insetter"
 
 @BindingAdapter(
     value = [
-        "consumeSystemWindowInsets",
+        "consumeWindowInsets",
         "paddingLeftSystemWindowInsets",
         "paddingTopSystemWindowInsets",
         "paddingRightSystemWindowInsets",
@@ -48,7 +48,7 @@ private const val TAG = "Insetter"
 )
 fun applyInsetsFromBooleans(
     v: View,
-    consumeSystemWindowInsets: Boolean,
+    consumeWindowInsets: Boolean,
     padSystemWindowLeft: Boolean,
     padSystemWindowTop: Boolean,
     padSystemWindowRight: Boolean,
@@ -103,7 +103,7 @@ fun applyInsetsFromBooleans(
                 marginSystemGestureBottom
             )
         )
-        .consume(if (consumeSystemWindowInsets) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
+        .consume(if (consumeWindowInsets) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
         .applyToView(v)
 }
 

--- a/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
+++ b/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
@@ -67,7 +67,8 @@ fun applyInsetsFromBooleans(
     marginSystemGestureBottom: Boolean
 ) {
     Insetter.builder()
-        .applySystemWindowInsetsToPadding(
+        .applyAsPadding(
+            windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
             Side.create(
                 padSystemWindowLeft,
                 padSystemWindowTop,
@@ -75,7 +76,8 @@ fun applyInsetsFromBooleans(
                 padSystemWindowBottom
             )
         )
-        .applySystemWindowInsetsToMargin(
+        .applyAsMargin(
+            windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
             Side.create(
                 marginSystemWindowLeft,
                 marginSystemWindowTop,
@@ -83,7 +85,8 @@ fun applyInsetsFromBooleans(
                 marginSystemWindowBottom
             )
         )
-        .applySystemGestureInsetsToPadding(
+        .applyAsPadding(
+            windowInsetTypesOf(systemGestures = true),
             Side.create(
                 padSystemGestureLeft,
                 padSystemGestureTop,
@@ -91,7 +94,8 @@ fun applyInsetsFromBooleans(
                 padSystemGestureBottom
             )
         )
-        .applySystemGestureInsetsToMargin(
+        .applyAsMargin(
+            windowInsetTypesOf(systemGestures = true),
             Side.create(
                 marginSystemGestureLeft,
                 marginSystemGestureTop,

--- a/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
+++ b/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
@@ -67,7 +67,7 @@ fun applyInsetsFromBooleans(
     marginSystemGestureBottom: Boolean
 ) {
     Insetter.builder()
-        .applyAsPadding(
+        .padding(
             windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
             Side.create(
                 padSystemWindowLeft,
@@ -76,7 +76,7 @@ fun applyInsetsFromBooleans(
                 padSystemWindowBottom
             )
         )
-        .applyAsMargin(
+        .margin(
             windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
             Side.create(
                 marginSystemWindowLeft,
@@ -85,7 +85,7 @@ fun applyInsetsFromBooleans(
                 marginSystemWindowBottom
             )
         )
-        .applyAsPadding(
+        .padding(
             windowInsetTypesOf(systemGestures = true),
             Side.create(
                 padSystemGestureLeft,
@@ -94,7 +94,7 @@ fun applyInsetsFromBooleans(
                 padSystemGestureBottom
             )
         )
-        .applyAsMargin(
+        .margin(
             windowInsetTypesOf(systemGestures = true),
             Side.create(
                 marginSystemGestureLeft,

--- a/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
+++ b/dbx/src/main/java/dev/chrisbanes/insetter/InsetterBindingAdapters.kt
@@ -99,7 +99,7 @@ fun applyInsetsFromBooleans(
                 marginSystemGestureBottom
             )
         )
-        .consumeSystemWindowInsets(consumeSystemWindowInsets)
+        .consume(if (consumeSystemWindowInsets) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
         .applyToView(v)
 }
 

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -11,10 +11,6 @@ public final class dev/chrisbanes/insetter/Insetter {
 }
 
 public final class dev/chrisbanes/insetter/Insetter$Builder {
-	public final fun applyAsMargin (II)Ldev/chrisbanes/insetter/Insetter$Builder;
-	public static synthetic fun applyAsMargin$default (Ldev/chrisbanes/insetter/Insetter$Builder;IIILjava/lang/Object;)Ldev/chrisbanes/insetter/Insetter$Builder;
-	public final fun applyAsPadding (II)Ldev/chrisbanes/insetter/Insetter$Builder;
-	public static synthetic fun applyAsPadding$default (Ldev/chrisbanes/insetter/Insetter$Builder;IIILjava/lang/Object;)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemGestureInsetsToMargin (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemGestureInsetsToPadding (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemWindowInsetsToMargin (I)Ldev/chrisbanes/insetter/Insetter$Builder;
@@ -24,6 +20,20 @@ public final class dev/chrisbanes/insetter/Insetter$Builder {
 	public final fun consume (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun consumeSystemWindowInsets (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun consumeSystemWindowInsets (Z)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun margin (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun margin (II)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public static synthetic fun margin$default (Ldev/chrisbanes/insetter/Insetter$Builder;IIILjava/lang/Object;)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun marginBottom (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun marginLeft (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun marginRight (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun marginTop (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun padding (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun padding (II)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public static synthetic fun padding$default (Ldev/chrisbanes/insetter/Insetter$Builder;IIILjava/lang/Object;)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun paddingBottom (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun paddingLeft (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun paddingRight (I)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun paddingTop (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun setOnApplyInsetsListener (Ldev/chrisbanes/insetter/OnApplyInsetsListener;)Ldev/chrisbanes/insetter/Insetter$Builder;
 }
 

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -11,12 +11,17 @@ public final class dev/chrisbanes/insetter/Insetter {
 }
 
 public final class dev/chrisbanes/insetter/Insetter$Builder {
+	public final fun applyAsMargin (II)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public static synthetic fun applyAsMargin$default (Ldev/chrisbanes/insetter/Insetter$Builder;IIILjava/lang/Object;)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public final fun applyAsPadding (II)Ldev/chrisbanes/insetter/Insetter$Builder;
+	public static synthetic fun applyAsPadding$default (Ldev/chrisbanes/insetter/Insetter$Builder;IIILjava/lang/Object;)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemGestureInsetsToMargin (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemGestureInsetsToPadding (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemWindowInsetsToMargin (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applySystemWindowInsetsToPadding (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun applyToView (Landroid/view/View;)Ldev/chrisbanes/insetter/Insetter;
 	public final fun build ()Ldev/chrisbanes/insetter/Insetter;
+	public final fun consume (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun consumeSystemWindowInsets (I)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun consumeSystemWindowInsets (Z)Ldev/chrisbanes/insetter/Insetter$Builder;
 	public final fun setOnApplyInsetsListener (Ldev/chrisbanes/insetter/OnApplyInsetsListener;)Ldev/chrisbanes/insetter/Insetter$Builder;
@@ -60,6 +65,11 @@ public final class dev/chrisbanes/insetter/Side {
 }
 
 public abstract interface annotation class dev/chrisbanes/insetter/Sides : java/lang/annotation/Annotation {
+}
+
+public final class dev/chrisbanes/insetter/TypesKt {
+	public static final fun windowInsetTypesOf (ZZZZZZZZ)I
+	public static synthetic fun windowInsetTypesOf$default (ZZZZZZZZILjava/lang/Object;)I
 }
 
 public final class dev/chrisbanes/insetter/ViewDimensions {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -55,6 +55,7 @@ android {
 
 dependencies {
     api Libs.AndroidX.core
+    api Libs.AndroidX.coreKtx
     implementation Libs.Kotlin.stdlib
 
     androidTestImplementation project(':test-utils')

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
@@ -24,34 +24,36 @@ import android.view.ViewGroup.MarginLayoutParams
 import androidx.annotation.IntDef
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.Insets
+import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnAttach
 import dev.chrisbanes.insetter.Insetter.Builder
 
 /**
- * A helper class to make handling [android.view.WindowInsets] easier.
+ * A class to make handling [android.view.WindowInsets] easier.
  *
  * It includes a [Builder] for building easy-to-use [OnApplyWindowInsetsListener]
  * instances:
  *
  * ```
  * Insetter.builder()
- *   // This will apply the system window insets as padding to left, bottom and right of the view
- *   .applySystemWindowInsetsToPadding(Side.LEFT | Side.BOTTOM | Side.RIGHT)
- *   // This is a shortcut for view.setOnApplyWindowInsetsListener(builder.build())
- *   .applyToView(view);
+ *     // This will apply the navigation bar insets as padding to all sides of the view
+ *     .padding(windowInsetTypesOf(navigationBars = true))
+ *     // This is a shortcut for view.setOnApplyWindowInsetsListener(builder.build())
+ *     .applyToView(view)
  * ```
  *
- * Each inset type as on Android 10 (API level 29) is included, with variants for applying the
- * inset as either padding or margin on the view.
+ * Each inset type available in [WindowInsetsCompat] is included, with variants for applying the
+ * inset as either padding or margin on the view, on specified sides.
  *
  * You can also provide custom logic via the [Builder.setOnApplyInsetsListener] function.
  * The listener type is slightly different to [OnApplyWindowInsetsListener], in that it contains
  * a third parameter to tell you what the initial view padding/margin state is.
  *
  * By default the listener will not consume any insets which are passed to it. If you wish to
- * consume the system window insets, you can use the [Builder.consume] function.
+ * consume the system window insets, you can specify the desired behavior via
+ * the [Builder.consume] function.
  */
 class Insetter private constructor(builder: Builder) {
     @IntDef(value = [CONSUME_NONE, CONSUME_ALL, CONSUME_AUTO])
@@ -70,7 +72,8 @@ class Insetter private constructor(builder: Builder) {
         private set
     internal var margin: SideApply
         private set
-    @ConsumeOptions private val consume: Int
+    @ConsumeOptions
+    private val consume: Int
 
     init {
         onApplyInsetsListener = builder.onApplyInsetsListener
@@ -111,6 +114,8 @@ class Insetter private constructor(builder: Builder) {
          * @see [paddingTop]
          * @see [paddingRight]
          * @see [paddingBottom]
+         * @see [windowInsetTypesOf]
+         * @see [Side.create]
          */
         @JvmOverloads
         fun padding(insetType: Int, @Sides sides: Int = Side.ALL): Builder {
@@ -124,6 +129,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun paddingLeft(insetType: Int): Builder = padding(insetType, Side.LEFT)
 
@@ -133,6 +140,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun paddingTop(insetType: Int): Builder = padding(insetType, Side.TOP)
 
@@ -142,6 +151,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun paddingRight(insetType: Int): Builder = padding(insetType, Side.RIGHT)
 
@@ -151,6 +162,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun paddingBottom(insetType: Int): Builder = padding(insetType, Side.BOTTOM)
 
@@ -167,6 +180,8 @@ class Insetter private constructor(builder: Builder) {
          * @see [marginTop]
          * @see [marginRight]
          * @see [marginBottom]
+         * @see [windowInsetTypesOf]
+         * @see [Side.create]
          */
         @JvmOverloads
         fun margin(insetType: Int, @Sides sides: Int = Side.ALL): Builder {
@@ -180,6 +195,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun marginLeft(insetType: Int): Builder = margin(insetType, Side.LEFT)
 
@@ -189,6 +206,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun marginTop(insetType: Int): Builder = margin(insetType, Side.TOP)
 
@@ -198,6 +217,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun marginRight(insetType: Int): Builder = margin(insetType, Side.RIGHT)
 
@@ -207,6 +228,8 @@ class Insetter private constructor(builder: Builder) {
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
          * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         *
+         * @see [windowInsetTypesOf]
          */
         fun marginBottom(insetType: Int): Builder = margin(insetType, Side.BOTTOM)
 
@@ -216,9 +239,9 @@ class Insetter private constructor(builder: Builder) {
          * @see Insetter.applyInsetsToView
          */
         @Deprecated(
-            "Replaced with applyAsPadding()",
+            "Replaced with padding()",
             ReplaceWith(
-                "applyAsPadding(windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true), sides)",
+                "padding(windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true), sides)",
                 "dev.chrisbanes.insetter.windowInsetTypesOf"
             )
         )
@@ -235,9 +258,9 @@ class Insetter private constructor(builder: Builder) {
          * @see Insetter.applyInsetsToView
          */
         @Deprecated(
-            "Replaced with applyAsMargin()",
+            "Replaced with margin()",
             ReplaceWith(
-                "applyAsMargin(windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true), sides)",
+                "margin(windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true), sides)",
                 "dev.chrisbanes.insetter.windowInsetTypesOf"
             )
         )
@@ -254,9 +277,9 @@ class Insetter private constructor(builder: Builder) {
          * @see Insetter.applyInsetsToView
          */
         @Deprecated(
-            "Replaced with applyAsPadding()",
+            "Replaced with padding()",
             ReplaceWith(
-                "applyAsPadding(windowInsetTypesOf(systemGestures = true), sides)",
+                "padding(windowInsetTypesOf(systemGestures = true), sides)",
                 "dev.chrisbanes.insetter.windowInsetTypesOf"
             )
         )
@@ -270,9 +293,9 @@ class Insetter private constructor(builder: Builder) {
          * @see Insetter.applyInsetsToView
          */
         @Deprecated(
-            "Replaced with applyAsMargin()",
+            "Replaced with margin()",
             ReplaceWith(
-                "applyAsMargin(windowInsetTypesOf(systemGestures = true), sides)",
+                "margin(windowInsetTypesOf(systemGestures = true), sides)",
                 "dev.chrisbanes.insetter.windowInsetTypesOf"
             )
         )

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
@@ -123,6 +123,13 @@ class Insetter private constructor(builder: Builder) {
          * to the padding. Ignored if [Insetter.onApplyInsetsListener] is set.
          * @see Insetter.applyInsetsToView
          */
+        @Deprecated(
+            "Replaced with applyAsPadding()",
+            ReplaceWith(
+                "applyAsPadding(windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true), sides)",
+                "dev.chrisbanes.insetter.windowInsetTypesOf"
+            )
+        )
         fun applySystemWindowInsetsToPadding(@Sides sides: Int): Builder {
             return applyAsPadding(
                 windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
@@ -135,6 +142,13 @@ class Insetter private constructor(builder: Builder) {
          * to the margin. Ignored if [Insetter.onApplyInsetsListener] is set.
          * @see Insetter.applyInsetsToView
          */
+        @Deprecated(
+            "Replaced with applyAsMargin()",
+            ReplaceWith(
+                "applyAsMargin(windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true), sides)",
+                "dev.chrisbanes.insetter.windowInsetTypesOf"
+            )
+        )
         fun applySystemWindowInsetsToMargin(@Sides sides: Int): Builder {
             return applyAsMargin(
                 windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
@@ -147,6 +161,13 @@ class Insetter private constructor(builder: Builder) {
          * to the padding. Ignored if [Insetter.onApplyInsetsListener] is set.
          * @see Insetter.applyInsetsToView
          */
+        @Deprecated(
+            "Replaced with applyAsPadding()",
+            ReplaceWith(
+                "applyAsPadding(windowInsetTypesOf(systemGestures = true), sides)",
+                "dev.chrisbanes.insetter.windowInsetTypesOf"
+            )
+        )
         fun applySystemGestureInsetsToPadding(@Sides sides: Int): Builder {
             return applyAsPadding(
                 windowInsetTypesOf(systemGestures = true),
@@ -159,6 +180,13 @@ class Insetter private constructor(builder: Builder) {
          * to the margin. Ignored if [Insetter.onApplyInsetsListener] is set.
          * @see Insetter.applyInsetsToView
          */
+        @Deprecated(
+            "Replaced with applyAsMargin()",
+            ReplaceWith(
+                "applyAsMargin(windowInsetTypesOf(systemGestures = true), sides)",
+                "dev.chrisbanes.insetter.windowInsetTypesOf"
+            )
+        )
         fun applySystemGestureInsetsToMargin(@Sides sides: Int): Builder {
             return applyAsMargin(
                 windowInsetTypesOf(systemGestures = true),

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
@@ -99,34 +99,116 @@ class Insetter private constructor(builder: Builder) {
         }
 
         /**
-         * Apply the given [WindowInsetsCompat.Type][insetType] as padding, on the given [sides]
-         * of the view.
+         * Apply the given [sides] dimension of the given [WindowInsetsCompat.Type][insetType]
+         * as the corresponding padding dimension of the view.
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
-         * @param sides Bit mask of [Side]s. Defaults to [Side.ALL] to apply all sides.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         * @param sides Bit mask of [Side]s containing which sides to apply.
+         * Defaults to [Side.ALL] to apply all sides. The mask can be created via [Side.create].
+         *
+         * @see [paddingLeft]
+         * @see [paddingTop]
+         * @see [paddingRight]
+         * @see [paddingBottom]
          */
-        fun applyAsPadding(
-            insetType: Int,
-            @Sides sides: Int = Side.ALL
-        ): Builder {
+        @JvmOverloads
+        fun padding(insetType: Int, @Sides sides: Int = Side.ALL): Builder {
             padding.add(insetType, sides)
             return this
         }
 
         /**
-         * Apply the given [WindowInsetsCompat.Type][insetType] as margin, on the given [sides]
-         * of the view.
+         * Apply the left value of the given [WindowInsetsCompat.Type][insetType] as the
+         * left padding of the view.
          *
          * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
-         * @param sides Bit mask of [Side]s. Defaults to [Side.ALL] to apply all sides.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
          */
-        fun applyAsMargin(
-            insetType: Int,
-            @Sides sides: Int = Side.ALL
-        ): Builder {
+        fun paddingLeft(insetType: Int): Builder = padding(insetType, Side.LEFT)
+
+        /**
+         * Apply the top value of the given [WindowInsetsCompat.Type][insetType] as the
+         * top padding of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun paddingTop(insetType: Int): Builder = padding(insetType, Side.TOP)
+
+        /**
+         * Apply the right value of the given [WindowInsetsCompat.Type][insetType] as the
+         * right padding of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun paddingRight(insetType: Int): Builder = padding(insetType, Side.RIGHT)
+
+        /**
+         * Apply the bottom value of the given [WindowInsetsCompat.Type][insetType] as the
+         * bottom padding of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun paddingBottom(insetType: Int): Builder = padding(insetType, Side.BOTTOM)
+
+        /**
+         * Apply the given [sides] dimension of the given [WindowInsetsCompat.Type][insetType]
+         * as the corresponding margin side of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         * @param sides Bit mask of [Side]s containing which sides to apply.
+         * Defaults to [Side.ALL] to apply all sides. The mask can be created via [Side.create].
+         *
+         * @see [marginLeft]
+         * @see [marginTop]
+         * @see [marginRight]
+         * @see [marginBottom]
+         */
+        @JvmOverloads
+        fun margin(insetType: Int, @Sides sides: Int = Side.ALL): Builder {
             margin.add(insetType, sides)
             return this
         }
+
+        /**
+         * Apply the left value of the given [WindowInsetsCompat.Type][insetType] as the
+         * left margin of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun marginLeft(insetType: Int): Builder = margin(insetType, Side.LEFT)
+
+        /**
+         * Apply the top value of the given [WindowInsetsCompat.Type][insetType] as the
+         * top margin of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun marginTop(insetType: Int): Builder = margin(insetType, Side.TOP)
+
+        /**
+         * Apply the right value of the given [WindowInsetsCompat.Type][insetType] as the
+         * right margin of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun marginRight(insetType: Int): Builder = margin(insetType, Side.RIGHT)
+
+        /**
+         * Apply the bottom value of the given [WindowInsetsCompat.Type][insetType] as the
+         * bottom margin of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as margin.
+         * The [windowInsetTypesOf] function is useful for creating the bit mask.
+         */
+        fun marginBottom(insetType: Int): Builder = margin(insetType, Side.BOTTOM)
 
         /**
          * @param sides specifies the sides on which the system window insets should be applied
@@ -141,7 +223,7 @@ class Insetter private constructor(builder: Builder) {
             )
         )
         fun applySystemWindowInsetsToPadding(@Sides sides: Int): Builder {
-            return applyAsPadding(
+            return padding(
                 windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
                 sides
             )
@@ -160,7 +242,7 @@ class Insetter private constructor(builder: Builder) {
             )
         )
         fun applySystemWindowInsetsToMargin(@Sides sides: Int): Builder {
-            return applyAsMargin(
+            return margin(
                 windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
                 sides
             )
@@ -179,10 +261,7 @@ class Insetter private constructor(builder: Builder) {
             )
         )
         fun applySystemGestureInsetsToPadding(@Sides sides: Int): Builder {
-            return applyAsPadding(
-                windowInsetTypesOf(systemGestures = true),
-                sides
-            )
+            return padding(windowInsetTypesOf(systemGestures = true), sides)
         }
 
         /**
@@ -198,10 +277,7 @@ class Insetter private constructor(builder: Builder) {
             )
         )
         fun applySystemGestureInsetsToMargin(@Sides sides: Int): Builder {
-            return applyAsMargin(
-                windowInsetTypesOf(systemGestures = true),
-                sides
-            )
+            return margin(windowInsetTypesOf(systemGestures = true), sides)
         }
 
         /**

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
@@ -396,38 +396,6 @@ class Insetter private constructor(builder: Builder) {
     }
 
     /**
-     * Function which consumes the insets for the given [type], if it exists in the [applied] types.
-     *
-     * @param windowInsets The original [WindowInsetsCompat] to retrieve the original insets from.
-     */
-    private fun WindowInsetsCompat.Builder.consumeType(
-        type: Int,
-        windowInsets: WindowInsetsCompat,
-        applied: SideApply,
-    ): WindowInsetsCompat.Builder {
-        // Fast path. If this type wasn't applied at all, no need to do anything
-        if (applied.all and type != type) return this
-
-        // First we get the original insets for the type
-        val insets = windowInsets.getInsets(type)
-
-        // If the insets are empty, nothing to do
-        if (insets == Insets.NONE) return this
-
-        // Now set the insets, selectively 'consuming' (zero-ing out) any consumed sides.
-        setInsets(
-            type,
-            Insets.of(
-                if (applied.left and type != 0) 0 else insets.left,
-                if (applied.top and type != 0) 0 else insets.top,
-                if (applied.right and type != 0) 0 else insets.right,
-                if (applied.bottom and type != 0) 0 else insets.bottom
-            )
-        )
-        return this
-    }
-
-    /**
      * A convenience function which applies insets to a view.
      *
      * How the given insets are applied depends on the options provided to the [Builder]
@@ -623,4 +591,36 @@ private fun View.applyMargins(
             parent.requestLayout()
         }
     }
+}
+
+/**
+ * Function which consumes the insets for the given [type], if it exists in the [applied] types.
+ *
+ * @param windowInsets The original [WindowInsetsCompat] to retrieve the original insets from.
+ */
+private fun WindowInsetsCompat.Builder.consumeType(
+    type: Int,
+    windowInsets: WindowInsetsCompat,
+    applied: Insetter.SideApply,
+): WindowInsetsCompat.Builder {
+    // Fast path. If this type wasn't applied at all, no need to do anything
+    if (applied.all and type != type) return this
+
+    // First we get the original insets for the type
+    val insets = windowInsets.getInsets(type)
+
+    // If the insets are empty, nothing to do
+    if (insets == Insets.NONE) return this
+
+    // Now set the insets, selectively 'consuming' (zero-ing out) any consumed sides.
+    setInsets(
+        type,
+        Insets.of(
+            if (applied.left and type != 0) 0 else insets.left,
+            if (applied.top and type != 0) 0 else insets.top,
+            if (applied.right and type != 0) 0 else insets.right,
+            if (applied.bottom and type != 0) 0 else insets.bottom
+        )
+    )
+    return this
 }

--- a/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/Insetter.kt
@@ -99,24 +99,32 @@ class Insetter private constructor(builder: Builder) {
         }
 
         /**
-         * TODO
+         * Apply the given [WindowInsetsCompat.Type][insetType] as padding, on the given [sides]
+         * of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
+         * @param sides Bit mask of [Side]s. Defaults to [Side.ALL] to apply all sides.
          */
         fun applyAsPadding(
-            insets: Int,
+            insetType: Int,
             @Sides sides: Int = Side.ALL
         ): Builder {
-            padding.add(insets, sides)
+            padding.add(insetType, sides)
             return this
         }
 
         /**
-         * TODO
+         * Apply the given [WindowInsetsCompat.Type][insetType] as margin, on the given [sides]
+         * of the view.
+         *
+         * @param insetType Bit mask of [WindowInsetsCompat.Type]s to apply as padding.
+         * @param sides Bit mask of [Side]s. Defaults to [Side.ALL] to apply all sides.
          */
         fun applyAsMargin(
-            insets: Int,
+            insetType: Int,
             @Sides sides: Int = Side.ALL
         ): Builder {
-            margin.add(insets, sides)
+            margin.add(insetType, sides)
             return this
         }
 

--- a/library/src/main/java/dev/chrisbanes/insetter/InsetterKtx.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/InsetterKtx.kt
@@ -68,7 +68,7 @@ inline fun View.applySystemWindowInsetsToPadding(
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applyAsPadding(
+    .padding(
         windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
         Side.create(left, top, right, bottom)
     )
@@ -91,7 +91,7 @@ inline fun View.applySystemWindowInsetsToMargin(
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applyAsMargin(
+    .margin(
         windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
         Side.create(left, top, right, bottom)
     )
@@ -114,7 +114,7 @@ inline fun View.applySystemGestureInsetsToPadding(
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applyAsPadding(
+    .padding(
         windowInsetTypesOf(systemGestures = true),
         Side.create(left, top, right, bottom)
     )
@@ -137,7 +137,7 @@ inline fun View.applySystemGestureInsetsToMargin(
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applyAsMargin(
+    .margin(
         windowInsetTypesOf(systemGestures = true),
         Side.create(left, top, right, bottom)
     )

--- a/library/src/main/java/dev/chrisbanes/insetter/InsetterKtx.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/InsetterKtx.kt
@@ -31,12 +31,9 @@ import androidx.core.view.WindowInsetsCompat
         "dev.chrisbanes.insetter.Insetter"
     )
 )
-inline fun View.doOnApplyWindowInsets(
-    crossinline f: (view: View, insets: WindowInsetsCompat, initialState: ViewState) -> Unit
-) = Insetter.builder()
-    .setOnApplyInsetsListener { view, insets, initialState ->
-        f(view, insets, initialState)
-    }.applyToView(this)
+fun View.doOnApplyWindowInsets(
+    f: (view: View, insets: WindowInsetsCompat, initialState: ViewState) -> Unit
+) = Insetter.builder().setOnApplyInsetsListener(f).applyToView(this)
 
 /**
  * Set this view's system-ui visibility, with the flags required to be laid out 'edge-to'edge.
@@ -46,11 +43,12 @@ inline fun View.doOnApplyWindowInsets(
  * @see View.setSystemUiVisibility
  * @see Insetter.setEdgeToEdgeSystemUiFlags
  */
-@Suppress("DEPRECATION")
 @RequiresApi(16)
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 @Deprecated("Use WindowCompat.setDecorFitsSystemWindows() instead")
-fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) =
+fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) {
     Insetter.setEdgeToEdgeSystemUiFlags(this, enabled)
+}
 
 /**
  * Apply the system window insets as the padding of this [View].
@@ -61,6 +59,7 @@ fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) =
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
  */
+@Suppress("DEPRECATION")
 fun View.applySystemWindowInsetsToPadding(
     left: Boolean = false,
     top: Boolean = false,
@@ -80,7 +79,8 @@ fun View.applySystemWindowInsetsToPadding(
  * @param right apply in the right indent if true
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
- * */
+ */
+@Suppress("DEPRECATION")
 fun View.applySystemWindowInsetsToMargin(
     left: Boolean = false,
     top: Boolean = false,
@@ -100,7 +100,8 @@ fun View.applySystemWindowInsetsToMargin(
  * @param right apply in the right indent if true
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
- * */
+ */
+@Suppress("DEPRECATION")
 fun View.applySystemGestureInsetsToPadding(
     left: Boolean = false,
     top: Boolean = false,
@@ -120,7 +121,8 @@ fun View.applySystemGestureInsetsToPadding(
  * @param right apply in the right indent if true
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
- * */
+ */
+@Suppress("DEPRECATION")
 fun View.applySystemGestureInsetsToMargin(
     left: Boolean = false,
     top: Boolean = false,

--- a/library/src/main/java/dev/chrisbanes/insetter/InsetterKtx.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/InsetterKtx.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("NOTHING_TO_INLINE")
+
 package dev.chrisbanes.insetter
 
 import android.view.View
@@ -46,7 +48,7 @@ fun View.doOnApplyWindowInsets(
 @RequiresApi(16)
 @Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
 @Deprecated("Use WindowCompat.setDecorFitsSystemWindows() instead")
-fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) {
+inline fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) {
     Insetter.setEdgeToEdgeSystemUiFlags(this, enabled)
 }
 
@@ -59,16 +61,18 @@ fun View.setEdgeToEdgeSystemUiFlags(enabled: Boolean = true) {
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
  */
-@Suppress("DEPRECATION")
-fun View.applySystemWindowInsetsToPadding(
+inline fun View.applySystemWindowInsetsToPadding(
     left: Boolean = false,
     top: Boolean = false,
     right: Boolean = false,
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applySystemWindowInsetsToPadding(Side.create(left, top, right, bottom))
-    .consumeSystemWindowInsets(consume)
+    .applyAsPadding(
+        windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
+        Side.create(left, top, right, bottom)
+    )
+    .consume(if (consume) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
     .applyToView(this)
 
 /**
@@ -80,16 +84,18 @@ fun View.applySystemWindowInsetsToPadding(
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
  */
-@Suppress("DEPRECATION")
-fun View.applySystemWindowInsetsToMargin(
+inline fun View.applySystemWindowInsetsToMargin(
     left: Boolean = false,
     top: Boolean = false,
     right: Boolean = false,
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applySystemWindowInsetsToMargin(Side.create(left, top, right, bottom))
-    .consumeSystemWindowInsets(consume)
+    .applyAsMargin(
+        windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
+        Side.create(left, top, right, bottom)
+    )
+    .consume(if (consume) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
     .applyToView(this)
 
 /**
@@ -101,16 +107,18 @@ fun View.applySystemWindowInsetsToMargin(
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
  */
-@Suppress("DEPRECATION")
-fun View.applySystemGestureInsetsToPadding(
+inline fun View.applySystemGestureInsetsToPadding(
     left: Boolean = false,
     top: Boolean = false,
     right: Boolean = false,
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applySystemGestureInsetsToPadding(Side.create(left, top, right, bottom))
-    .consumeSystemWindowInsets(consume)
+    .applyAsPadding(
+        windowInsetTypesOf(systemGestures = true),
+        Side.create(left, top, right, bottom)
+    )
+    .consume(if (consume) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
     .applyToView(this)
 
 /**
@@ -122,14 +130,16 @@ fun View.applySystemGestureInsetsToPadding(
  * @param bottom apply in the bottom indent if true
  * @param consume consume the system window insets if true
  */
-@Suppress("DEPRECATION")
-fun View.applySystemGestureInsetsToMargin(
+inline fun View.applySystemGestureInsetsToMargin(
     left: Boolean = false,
     top: Boolean = false,
     right: Boolean = false,
     bottom: Boolean = false,
     consume: Boolean = false
 ) = Insetter.builder()
-    .applySystemGestureInsetsToMargin(Side.create(left, top, right, bottom))
-    .consumeSystemWindowInsets(consume)
+    .applyAsMargin(
+        windowInsetTypesOf(systemGestures = true),
+        Side.create(left, top, right, bottom)
+    )
+    .consume(if (consume) Insetter.CONSUME_ALL else Insetter.CONSUME_NONE)
     .applyToView(this)

--- a/library/src/main/java/dev/chrisbanes/insetter/LayoutParams.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/LayoutParams.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.chrisbanes.insetter
+
+import android.view.ViewGroup
+import androidx.annotation.Px
+
+internal fun ViewGroup.MarginLayoutParams.updateMargins(
+    @Px left: Int = leftMargin,
+    @Px top: Int = topMargin,
+    @Px right: Int = rightMargin,
+    @Px bottom: Int = bottomMargin
+): Boolean {
+    if (left != leftMargin || top != topMargin || right != rightMargin || bottom != bottomMargin) {
+        setMargins(left, top, right, bottom)
+        return true
+    }
+    return false
+}

--- a/library/src/main/java/dev/chrisbanes/insetter/Types.kt
+++ b/library/src/main/java/dev/chrisbanes/insetter/Types.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.chrisbanes.insetter
+
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Convenienve function for building a combination of [WindowInsetsCompat.Type] values.
+ */
+fun windowInsetTypesOf(
+    ime: Boolean = false,
+    navigationBars: Boolean = false,
+    statusBars: Boolean = false,
+    systemGestures: Boolean = false,
+    mandatorySystemGestures: Boolean = false,
+    displayCutout: Boolean = false,
+    captionBar: Boolean = false,
+    tappableElement: Boolean = false,
+): Int {
+    var flag = 0
+    if (ime) flag = flag or WindowInsetsCompat.Type.ime()
+    if (navigationBars) flag = flag or WindowInsetsCompat.Type.navigationBars()
+    if (statusBars) flag = flag or WindowInsetsCompat.Type.statusBars()
+    if (systemGestures) flag = flag or WindowInsetsCompat.Type.systemGestures()
+    if (displayCutout) flag = flag or WindowInsetsCompat.Type.displayCutout()
+    if (captionBar) flag = flag or WindowInsetsCompat.Type.captionBar()
+    if (tappableElement) flag = flag or WindowInsetsCompat.Type.tappableElement()
+    if (mandatorySystemGestures) flag = flag or WindowInsetsCompat.Type.mandatorySystemGestures()
+    return flag
+}

--- a/widgets/api/widgets.api
+++ b/widgets/api/widgets.api
@@ -4,6 +4,7 @@ public class dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraint
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConsumeSystemWindowInsets ()I
+	public final fun getConsumeWindowInsets ()I
 	public final fun getSystemGestureInsetsMarginSides ()I
 	public final fun getSystemGestureInsetsPaddingSides ()I
 	public final fun getSystemWindowInsetsMarginSides ()I
@@ -11,6 +12,7 @@ public class dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraint
 	public fun onApplyWindowInsets (Landroid/view/WindowInsets;)Landroid/view/WindowInsets;
 	protected fun onAttachedToWindow ()V
 	public final fun setConsumeSystemWindowInsets (I)V
+	public final fun setConsumeWindowInsets (I)V
 	public final fun setSystemGestureInsetsMarginSides (I)V
 	public final fun setSystemGestureInsetsPaddingSides (I)V
 	public final fun setSystemWindowInsetsMarginSides (I)V
@@ -42,11 +44,13 @@ public class dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraint
 	public fun <init> (Landroidx/constraintlayout/widget/ConstraintLayout$LayoutParams;)V
 	public fun <init> (Ldev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout$LayoutParams;)V
 	public final fun getConsumeSystemWindowInsets ()I
+	public final fun getConsumeWindowInsets ()I
 	public final fun getSystemGestureInsetsMarginSides ()I
 	public final fun getSystemGestureInsetsPaddingSides ()I
 	public final fun getSystemWindowInsetsMarginSides ()I
 	public final fun getSystemWindowInsetsPaddingSides ()I
 	public final fun setConsumeSystemWindowInsets (I)V
+	public final fun setConsumeWindowInsets (I)V
 	public final fun setSystemGestureInsetsMarginSides (I)V
 	public final fun setSystemGestureInsetsPaddingSides (I)V
 	public final fun setSystemWindowInsetsMarginSides (I)V

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
@@ -238,6 +238,6 @@ open class InsetterConstraintHelper @JvmOverloads constructor(
         .applySystemWindowInsetsToMargin(systemWindowInsetsMarginSides)
         .applySystemGestureInsetsToPadding(systemGestureInsetsPaddingSides)
         .applySystemGestureInsetsToMargin(systemGestureInsetsMarginSides)
-        .consumeSystemWindowInsets(consumeSystemWindowInsets)
+        .consume(consumeSystemWindowInsets)
         .build()
 }

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
@@ -235,19 +235,19 @@ open class InsetterConstraintHelper @JvmOverloads constructor(
     }
 
     private fun buildInsetter(): Insetter = Insetter.builder()
-        .applyAsPadding(
+        .padding(
             windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
             systemWindowInsetsPaddingSides
         )
-        .applyAsMargin(
+        .margin(
             windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
             systemWindowInsetsMarginSides
         )
-        .applyAsPadding(
+        .padding(
             windowInsetTypesOf(systemGestures = true),
             systemGestureInsetsPaddingSides
         )
-        .applyAsMargin(
+        .margin(
             windowInsetTypesOf(systemGestures = true),
             systemGestureInsetsMarginSides
         )

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
@@ -127,13 +127,19 @@ open class InsetterConstraintHelper @JvmOverloads constructor(
     }
 
     /**
-     * Whether how to consume the system window insets. Can be one of
-     * [Insetter.CONSUME_ALL] or [Insetter.CONSUME_AUTO].
+     * The behavior of consuming the window insets. Can be one of
+     * [Insetter.CONSUME_ALL], [Insetter.CONSUME_AUTO] or [Insetter.CONSUME_NONE].
      */
     @delegate:Insetter.ConsumeOptions
-    var consumeSystemWindowInsets: Int by observable(0) { _, _, _ ->
+    var consumeWindowInsets: Int by observable(0) { _, _, _ ->
         invalidateInsetter()
     }
+
+    @Deprecated("Replaced with consumeWindowInsets", ReplaceWith("consumeWindowInsets"))
+    @Insetter.ConsumeOptions
+    var consumeSystemWindowInsets: Int
+        get() = consumeWindowInsets
+        set(value) { consumeWindowInsets = value }
 
     /**
      * The sides on which system window insets should be applied to the margin.
@@ -184,9 +190,9 @@ open class InsetterConstraintHelper @JvmOverloads constructor(
         )
         systemGestureInsetsMarginSides = flagToSides(marginSystemGestureInsetsFlags)
 
-        consumeSystemWindowInsets = ta.getInt(
-            R.styleable.InsetterConstraintHelper_consumeSystemWindowInsets,
-            consumeSystemWindowInsets
+        consumeWindowInsets = ta.getInt(
+            R.styleable.InsetterConstraintHelper_consumeWindowInsets,
+            consumeWindowInsets
         )
 
         ta.recycle()
@@ -251,6 +257,6 @@ open class InsetterConstraintHelper @JvmOverloads constructor(
             windowInsetTypesOf(systemGestures = true),
             systemGestureInsetsMarginSides
         )
-        .consume(consumeSystemWindowInsets)
+        .consume(consumeWindowInsets)
         .build()
 }

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.kt
@@ -28,6 +28,7 @@ import dev.chrisbanes.insetter.Insetter
 import dev.chrisbanes.insetter.Sides
 import dev.chrisbanes.insetter.ViewState
 import dev.chrisbanes.insetter.widgets.R
+import dev.chrisbanes.insetter.windowInsetTypesOf
 import kotlin.properties.Delegates.observable
 
 /**
@@ -234,10 +235,22 @@ open class InsetterConstraintHelper @JvmOverloads constructor(
     }
 
     private fun buildInsetter(): Insetter = Insetter.builder()
-        .applySystemWindowInsetsToPadding(systemWindowInsetsPaddingSides)
-        .applySystemWindowInsetsToMargin(systemWindowInsetsMarginSides)
-        .applySystemGestureInsetsToPadding(systemGestureInsetsPaddingSides)
-        .applySystemGestureInsetsToMargin(systemGestureInsetsMarginSides)
+        .applyAsPadding(
+            windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
+            systemWindowInsetsPaddingSides
+        )
+        .applyAsMargin(
+            windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
+            systemWindowInsetsMarginSides
+        )
+        .applyAsPadding(
+            windowInsetTypesOf(systemGestures = true),
+            systemGestureInsetsPaddingSides
+        )
+        .applyAsMargin(
+            windowInsetTypesOf(systemGestures = true),
+            systemGestureInsetsMarginSides
+        )
         .consume(consumeSystemWindowInsets)
         .build()
 }

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
@@ -222,19 +222,19 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
         }
 
         private fun buildInsetter(): Insetter = Insetter.builder()
-            .applyAsPadding(
+            .padding(
                 windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
                 systemWindowInsetsPaddingSides
             )
-            .applyAsMargin(
+            .margin(
                 windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
                 systemWindowInsetsMarginSides
             )
-            .applyAsPadding(
+            .padding(
                 windowInsetTypesOf(systemGestures = true),
                 systemGestureInsetsPaddingSides
             )
-            .applyAsMargin(
+            .margin(
                 windowInsetTypesOf(systemGestures = true),
                 systemGestureInsetsMarginSides
             )

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
@@ -30,6 +30,7 @@ import dev.chrisbanes.insetter.Insetter
 import dev.chrisbanes.insetter.Sides
 import dev.chrisbanes.insetter.ViewState
 import dev.chrisbanes.insetter.widgets.R
+import dev.chrisbanes.insetter.windowInsetTypesOf
 import kotlin.properties.Delegates.observable
 
 /**
@@ -221,10 +222,22 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
         }
 
         private fun buildInsetter(): Insetter = Insetter.builder()
-            .applySystemWindowInsetsToPadding(systemWindowInsetsPaddingSides)
-            .applySystemWindowInsetsToMargin(systemWindowInsetsMarginSides)
-            .applySystemGestureInsetsToPadding(systemGestureInsetsPaddingSides)
-            .applySystemGestureInsetsToMargin(systemGestureInsetsMarginSides)
+            .applyAsPadding(
+                windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
+                systemWindowInsetsPaddingSides
+            )
+            .applyAsMargin(
+                windowInsetTypesOf(ime = true, statusBars = true, navigationBars = true),
+                systemWindowInsetsMarginSides
+            )
+            .applyAsPadding(
+                windowInsetTypesOf(systemGestures = true),
+                systemGestureInsetsPaddingSides
+            )
+            .applyAsMargin(
+                windowInsetTypesOf(systemGestures = true),
+                systemGestureInsetsMarginSides
+            )
             .consume(consumeSystemWindowInsets)
             .build()
 

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
@@ -225,7 +225,7 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
             .applySystemWindowInsetsToMargin(systemWindowInsetsMarginSides)
             .applySystemGestureInsetsToPadding(systemGestureInsetsPaddingSides)
             .applySystemGestureInsetsToMargin(systemGestureInsetsMarginSides)
-            .consumeSystemWindowInsets(consumeSystemWindowInsets)
+            .consume(consumeSystemWindowInsets)
             .build()
 
         private fun invalidateInsetter() {

--- a/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
+++ b/widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.kt
@@ -144,11 +144,17 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
         var systemGestureInsetsPaddingSides: Int by observable(0) { _, _, _ -> invalidateInsetter() }
 
         /**
-         * Whether how to consume the system window insets. Can be one of
-         * [Insetter.CONSUME_ALL] or [Insetter.CONSUME_AUTO].
+         * The behavior of consuming the window insets. Can be one of
+         * [Insetter.CONSUME_ALL], [Insetter.CONSUME_AUTO] or [Insetter.CONSUME_NONE].
          */
         @delegate:Insetter.ConsumeOptions
-        var consumeSystemWindowInsets: Int by observable(0) { _, _, _ -> invalidateInsetter() }
+        var consumeWindowInsets: Int by observable(0) { _, _, _ -> invalidateInsetter() }
+
+        @Deprecated("Replaced with consumeWindowInsets", ReplaceWith("consumeWindowInsets"))
+        @Insetter.ConsumeOptions
+        var consumeSystemWindowInsets: Int
+            get() = consumeWindowInsets
+            set(value) { consumeWindowInsets = value }
 
         /**
          * The sides on which system window insets should be applied to the margin.
@@ -175,7 +181,7 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
         constructor(source: LayoutParams) : super(source) {
             systemWindowInsetsPaddingSides = source.systemWindowInsetsPaddingSides
             systemWindowInsetsMarginSides = source.systemWindowInsetsMarginSides
-            consumeSystemWindowInsets = source.consumeSystemWindowInsets
+            consumeWindowInsets = source.consumeWindowInsets
             systemGestureInsetsPaddingSides = source.systemGestureInsetsPaddingSides
             systemGestureInsetsMarginSides = source.systemGestureInsetsMarginSides
         }
@@ -207,9 +213,9 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
             )
             systemGestureInsetsMarginSides = flagToSides(marginSystemGestureInsetsFlags)
 
-            consumeSystemWindowInsets = ta.getInt(
-                R.styleable.InsetterConstraintLayout_Layout_consumeSystemWindowInsets,
-                consumeSystemWindowInsets
+            consumeWindowInsets = ta.getInt(
+                R.styleable.InsetterConstraintLayout_Layout_consumeWindowInsets,
+                consumeWindowInsets
             )
 
             ta.recycle()
@@ -238,7 +244,7 @@ open class InsetterConstraintLayout @JvmOverloads constructor(
                 windowInsetTypesOf(systemGestures = true),
                 systemGestureInsetsMarginSides
             )
-            .consume(consumeSystemWindowInsets)
+            .consume(consumeWindowInsets)
             .build()
 
         private fun invalidateInsetter() {

--- a/widgets/src/main/res/values/attrs.xml
+++ b/widgets/src/main/res/values/attrs.xml
@@ -57,7 +57,7 @@
         <flag name="right" value="0x05" />
     </attr>
 
-    <attr name="consumeSystemWindowInsets">
+    <attr name="consumeWindowInsets">
         <enum name="none" value="0" />
         <enum name="all" value="1" />
         <enum name="auto" value="2" />
@@ -66,7 +66,8 @@
     <declare-styleable name="InsetterConstraintLayout_Layout">
         <attr name="paddingSystemWindowInsets" />
         <attr name="layout_marginSystemWindowInsets" />
-        <attr name="consumeSystemWindowInsets" />
+
+        <attr name="consumeWindowInsets" />
 
         <attr name="paddingSystemGestureInsets" />
         <attr name="layout_marginSystemGestureInsets" />
@@ -75,7 +76,8 @@
     <declare-styleable name="InsetterConstraintHelper">
         <attr name="paddingSystemWindowInsets" />
         <attr name="layout_marginSystemWindowInsets" />
-        <attr name="consumeSystemWindowInsets" />
+
+        <attr name="consumeWindowInsets" />
 
         <attr name="paddingSystemGestureInsets" />
         <attr name="layout_marginSystemGestureInsets" />


### PR DESCRIPTION
The new API:

``` kotlin
// kotlin
Insetter.builder()
    // This will apply the navigation + status bar insets as padding to
    // all sides of the view
    .padding(windowInsetTypesOf(navigationBars = true, statusBars = true))
    // There's also paddingLeft(), paddingTop(), etc for specific sides
    
    // This will apply the navigation bar insets as bottom margin on the view
    .marginBottom(windowInsetTypesOf(navigationBars = true))
    // Similarly, there's also margin(), marginLeft(), etc
    
    // Applies this to the view
    .applyToView(view)
```

``` java
// java
Insetter.builder()
    // This will apply the navigation + status bar insets as padding to
    // all sides of the view.
    .padding(WindowInsetsCompat.Type.navigationBars()
        | WindowInsetsCompat.Type.statusBars())
    // There's also paddingLeft(), paddingTop(), etc for specific sides
    
    // This will apply the navigation bar insets as bottom margin on the view
    .marginBottom(WindowInsetsCompat.Type.navigationBars())
    // Similarly, there's also margin(), marginLeft(), etc
    
    // Applies this to the view
    .applyToView(view);
```

### Breaking changes

- DBX: `app:consumeSystemWindowInsets` has been renamed to `app:consumeWindowInsets`
- Widgets: `app:consumeSystemWindowInsets` has been renamed to `app:consumeWindowInsets`