### PR TITLE
Correct a mistake in library doc example

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -55,7 +55,7 @@ view.applyInsetter {
     }
 
     // Apply the status bar insets...
-    type(navigationBars = true) {
+    type(statusBars = true) {
         // Add to margin on all sides
         margin()
     }


### PR DESCRIPTION
Correct the mistake where the status bar example was showing navigation bar case instead.