### PR TITLE
Set Kotlin module name to fix library conflict

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,6 +29,12 @@ kotlin {
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        kotlinOptions {
+            freeCompilerArgs += ['-module-name', 'insetter']
+        }
+    }
+
     defaultConfig {
         minSdkVersion 15
 


### PR DESCRIPTION
By default, the Kotlin compiler creates a kotlin_module file with the name of the Gradle module. The resulting name is `library_release.kotlin_module` for this library, which conflicts with other libraries that also use the default generic "library" name. This causes builds to fail when multiple such libraries are used in the same project:

```
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > More than one file was found with OS independent path 'META-INF/library_release.kotlin_module'.
```

Set a unique Kotlin module name to fix the issue.