### PR TITLE
Fix MkDocs URIs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ An extension library which provides versions of commonly used ViewGroups with en
 handling. Currently this library is focusing on building upon 
 [`ConstraintLayout`](https://developer.android.com/reference/androidx/constraintlayout/widget/ConstraintLayout.html).
 
-A example of a widget is [InsetterConstraintLayout](widgets/src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.java),
+A example of a widget is [InsetterConstraintLayout][icl],
 which enables new attributes to define inset behavior on child views:
 
 ``` xml
@@ -118,4 +118,5 @@ limitations under the License.
 ```
 
 [databinding]: https://developer.android.com/topic/libraries/data-binding
+[icl]: api/widgets/widgets/dev.chrisbanes.insetter.widgets.constraintlayout/-insetter-constraint-layout/
 [snap]: https://oss.sonatype.org/content/repositories/snapshots/

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -242,5 +242,5 @@ this library provide very similar functionality at the cost of having to migrate
 [cl]: https://developer.android.com/reference/androidx/constraintlayout/widget/ConstraintLayout.html
 [swi]: https://developer.android.com/reference/androidx/core/view/WindowInsetsCompat.html#getSystemWindowInsets()
 [sgi]: https://developer.android.com/reference/androidx/core/view/WindowInsetsCompat.html#getSystemGestureInsets()
-[icl]: src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintLayout.java
-[ich]: src/main/java/dev/chrisbanes/insetter/widgets/constraintlayout/InsetterConstraintHelper.java
+[icl]: ../api/widgets/widgets/dev.chrisbanes.insetter.widgets.constraintlayout/-insetter-constraint-layout/
+[ich]: ../api/widgets/widgets/dev.chrisbanes.insetter.widgets.constraintlayout/-insetter-constraint-helper/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_description: 'Insetter is a library to help make handling WindowInsets easy
 site_author: 'Chris Banes'
 site_url: 'https://chrisbanes.github.io/insetter/'
 remote_branch: gh-pages
+edit_uri: 'edit/main/docs/'
 
 docs_dir: docs-gen
 


### PR DESCRIPTION
- Override default edit_uri since we moved default branch from `master` to `main`
- Fix links to API reference (we might have to double check the output)